### PR TITLE
Fix register after multiple attempts with invalid email.

### DIFF
--- a/app/src/androidTest/java/com/okta/idx/android/SelfServiceRegistrationTest.kt
+++ b/app/src/androidTest/java/com/okta/idx/android/SelfServiceRegistrationTest.kt
@@ -50,6 +50,12 @@ class SelfServiceRegistrationTest : BaseMainActivityTest() {
         networkRule.enqueue(path("idp/idx/introspect")) { response ->
             response.testBodyFromFile("$mockPrefix/introspect.json")
         }
+        networkRule.enqueue(path("oauth2/default/v1/interact")) { response ->
+            response.testBodyFromFile("$mockPrefix/interact.json")
+        }
+        networkRule.enqueue(path("idp/idx/introspect")) { response ->
+            response.testBodyFromFile("$mockPrefix/introspect.json")
+        }
         networkRule.enqueue(path("idp/idx/enroll")) { response ->
             response.testBodyFromFile("$mockPrefix/enroll.json")
         }
@@ -128,6 +134,12 @@ class SelfServiceRegistrationTest : BaseMainActivityTest() {
     // optional SMS
     @Test fun scenario_4_1_2() {
         val mockPrefix = "scenario_4_1_2"
+        networkRule.enqueue(path("oauth2/default/v1/interact")) { response ->
+            response.testBodyFromFile("$mockPrefix/interact.json")
+        }
+        networkRule.enqueue(path("idp/idx/introspect")) { response ->
+            response.testBodyFromFile("$mockPrefix/introspect.json")
+        }
         networkRule.enqueue(path("oauth2/default/v1/interact")) { response ->
             response.testBodyFromFile("$mockPrefix/interact.json")
         }
@@ -259,6 +271,12 @@ class SelfServiceRegistrationTest : BaseMainActivityTest() {
         networkRule.enqueue(path("idp/idx/introspect")) { response ->
             response.testBodyFromFile("$mockPrefix/introspect.json")
         }
+        networkRule.enqueue(path("oauth2/default/v1/interact")) { response ->
+            response.testBodyFromFile("$mockPrefix/interact.json")
+        }
+        networkRule.enqueue(path("idp/idx/introspect")) { response ->
+            response.testBodyFromFile("$mockPrefix/introspect.json")
+        }
         networkRule.enqueue(path("idp/idx/enroll")) { response ->
             response.testBodyFromFile("$mockPrefix/enroll.json")
         }
@@ -294,6 +312,12 @@ class SelfServiceRegistrationTest : BaseMainActivityTest() {
     // optional SMS with an invalid phone number
     @Test fun scenario_4_1_4() {
         val mockPrefix = "scenario_4_1_4"
+        networkRule.enqueue(path("oauth2/default/v1/interact")) { response ->
+            response.testBodyFromFile("$mockPrefix/interact.json")
+        }
+        networkRule.enqueue(path("idp/idx/introspect")) { response ->
+            response.testBodyFromFile("$mockPrefix/introspect.json")
+        }
         networkRule.enqueue(path("oauth2/default/v1/interact")) { response ->
             response.testBodyFromFile("$mockPrefix/interact.json")
         }


### PR DESCRIPTION
Due to the way the underlying API works, we can get into a situation where the identify call succeeds, and we have a proceed context that's in the wrong state.

I originally used the begin context from the login page to optimize network calls. But it causes issues due to the way the API/SDK is implemented.

See OKTA-403240