### PR TITLE
Treat 500+ http status codes as error

### DIFF
--- a/dynamic-app/src/main/java/com/okta/idx/android/dynamic/auth/DynamicAuthViewModel.kt
+++ b/dynamic-app/src/main/java/com/okta/idx/android/dynamic/auth/DynamicAuthViewModel.kt
@@ -109,7 +109,7 @@ internal class DynamicAuthViewModel(private val recoveryToken: String) : ViewMod
                 when (val resumeResult = localFlow.resume()) {
                     is OidcClientResult.Error -> {
                         Timber.e(resumeResult.exception, "Failed to call resume")
-                        _state.value = DynamicAuthState.Error("Failed to call resume")
+                        _state.value = DynamicAuthState.Error("Failed to call resume with exception: ${resumeResult.exception}")
                     }
                     is OidcClientResult.Success -> {
                         handleResponse(resumeResult.result)

--- a/idx-kotlin/src/main/java/com/okta/idx/kotlin/client/InteractionCodeFlow.kt
+++ b/idx-kotlin/src/main/java/com/okta/idx/kotlin/client/InteractionCodeFlow.kt
@@ -201,7 +201,7 @@ class InteractionCodeFlow internal constructor(
     }
 
     /** IdxResponse can come back in both HTTP 200 as well as others such as 400s. */
-    private fun idxShouldAttemptJsonDeserialization(@Suppress("UNUSED_PARAMETER") response: Response): Boolean {
-        return true
+    private fun idxShouldAttemptJsonDeserialization(response: Response): Boolean {
+        return response.code < 500
     }
 }


### PR DESCRIPTION
This matches the behavior in okta-idx-swift: https://github.com/okta/okta-idx-swift/blob/e2e3cf75361be42c302bd7c6e7cda008064d1bc0/Sources/OktaIdx/Internal/Implementations/Version1/Requests/RemediationRequest.swift#LL50C12-L50C12

Also, in practice, 500+ error codes seem to be providing empty body in IDX responses.