### PR TITLE
Update dependencies

### DIFF
--- a/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/definitions/LaunchDefinitions.kt
+++ b/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/definitions/LaunchDefinitions.kt
@@ -34,6 +34,8 @@ import com.okta.idx.android.infrastructure.LAUNCH_TITLE_TEXT_VIEW
 import com.okta.idx.android.infrastructure.PROGRESS_BAR_VIEW
 import com.okta.idx.android.infrastructure.espresso.waitForElement
 import com.okta.idx.android.infrastructure.espresso.waitForElementToBeGone
+import com.okta.idx.android.infrastructure.management.OktaManagementSdk
+import com.okta.sdk.resource.api.UserApi
 import io.cucumber.java.en.And
 import io.cucumber.java.en.Given
 import io.cucumber.java.en.Then
@@ -53,8 +55,9 @@ class LaunchDefinitions {
     @Given("^Mary bootstraps the application with a recovery token$")
     fun mary_bootstraps_the_application_with_a_recovery_token() {
         waitForElement(LAUNCH_TITLE_TEXT_VIEW)
-        val response = SharedState.user!!.forgotPasswordGenerateOneTimeToken(false)
-        val recoveryToken = response.resetPasswordUrl.substringAfterLast("/")
+        val userApi = UserApi(OktaManagementSdk.client)
+        val response = userApi.generateResetPasswordToken(SharedState.user!!.id, false, false)
+        val recoveryToken = response.resetPasswordUrl!!.substringAfterLast("/")
         onView(withHint(R.string.recovery_token)).perform(replaceText(recoveryToken))
         onView(withId(R.id.login_button)).perform(click())
     }

--- a/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/hooks/EnrollSecurityQuestion.kt
+++ b/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/hooks/EnrollSecurityQuestion.kt
@@ -16,7 +16,10 @@
 package com.okta.idx.android.cucumber.hooks
 
 import com.okta.idx.android.infrastructure.management.OktaManagementSdk
-import com.okta.sdk.resource.user.factor.SecurityQuestionUserFactor
+import com.okta.sdk.resource.api.UserFactorApi
+import com.okta.sdk.resource.model.FactorType
+import com.okta.sdk.resource.model.SecurityQuestionUserFactor
+import com.okta.sdk.resource.model.SecurityQuestionUserFactorProfile
 import io.cucumber.java.Before
 import org.junit.Assert
 import java.util.UUID
@@ -28,11 +31,16 @@ class EnrollSecurityQuestion {
 
     @Before("@enrollSecurityQuestion") fun requireEnrolledSecurityQuestion() {
         Assert.assertNotNull(SharedState.user)
-        val factor: SecurityQuestionUserFactor =
-            OktaManagementSdk.client.instantiate(SecurityQuestionUserFactor::class.java)
-        factor.profile.question = "disliked_food"
-        factor.profile.questionText = "What is the food you least liked as a child?"
-        factor.profile.answer = ANSWER
-        SharedState.user!!.enrollFactor(factor, false, null, null, true)
+        val userFactorApi = UserFactorApi(OktaManagementSdk.client)
+        val factor = SecurityQuestionUserFactor().apply {
+            setProfile(
+                SecurityQuestionUserFactorProfile()
+                    .question("disliked_food")
+                    .questionText("What is the food you least liked as a child?")
+                    .answer(ANSWER)
+            )
+            factorType(FactorType.QUESTION)
+        }
+        userFactorApi.enrollFactor(SharedState.user!!.id, factor, false, null, null, true)
     }
 }

--- a/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/hooks/RequireEnrolledPhone.kt
+++ b/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/hooks/RequireEnrolledPhone.kt
@@ -16,7 +16,10 @@
 package com.okta.idx.android.cucumber.hooks
 
 import com.okta.idx.android.infrastructure.management.OktaManagementSdk
-import com.okta.sdk.resource.user.factor.SmsUserFactor
+import com.okta.sdk.resource.api.UserFactorApi
+import com.okta.sdk.resource.model.FactorType
+import com.okta.sdk.resource.model.SmsUserFactor
+import com.okta.sdk.resource.model.SmsUserFactorProfile
 import io.cucumber.java.Before
 import org.junit.Assert
 
@@ -24,9 +27,14 @@ class RequireEnrolledPhone {
     @Before("@requireEnrolledPhone") fun enrollSmsUserFactor() {
         Assert.assertNotNull(SharedState.a18NProfile)
         Assert.assertNotNull(SharedState.user)
-        val smsUserFactor: SmsUserFactor =
-            OktaManagementSdk.client.instantiate(SmsUserFactor::class.java)
-        smsUserFactor.profile.phoneNumber = SharedState.a18NProfile!!.phoneNumber
-        SharedState.user!!.enrollFactor(smsUserFactor, false, null, null, true)
+        val userFactorApi = UserFactorApi(OktaManagementSdk.client)
+        val smsUserFactor: SmsUserFactor = SmsUserFactor().apply {
+            setProfile(
+                SmsUserFactorProfile()
+                    .phoneNumber(SharedState.a18NProfile!!.phoneNumber)
+            )
+            factorType(FactorType.SMS)
+        }
+        userFactorApi.enrollFactor(SharedState.user!!.id, smsUserFactor, false, null, null, true)
     }
 }

--- a/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/hooks/SharedState.kt
+++ b/dynamic-app/src/androidTest/java/com/okta/idx/android/cucumber/hooks/SharedState.kt
@@ -17,7 +17,7 @@ package com.okta.idx.android.cucumber.hooks
 
 import android.app.Activity
 import com.okta.idx.android.infrastructure.a18n.A18NProfile
-import com.okta.sdk.resource.user.User
+import com.okta.sdk.resource.model.User
 import io.cucumber.java.After
 
 class SharedState {

--- a/dynamic-app/src/androidTest/java/com/okta/idx/android/infrastructure/management/OktaManagementSdk.kt
+++ b/dynamic-app/src/androidTest/java/com/okta/idx/android/infrastructure/management/OktaManagementSdk.kt
@@ -16,11 +16,11 @@
 package com.okta.idx.android.infrastructure.management
 
 import com.okta.idx.android.infrastructure.EndToEndCredentials
-import com.okta.sdk.client.Client
 import com.okta.sdk.client.Clients
+import com.okta.sdk.resource.client.ApiClient
 
 object OktaManagementSdk {
-    val client: Client = Clients.builder()
+    val client: ApiClient = Clients.builder()
         .setClientId(EndToEndCredentials["/managementSdk/clientId"])
         .setOrgUrl(EndToEndCredentials["/managementSdk/orgUrl"])
         .setClientCredentials { EndToEndCredentials["/managementSdk/token"] }

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,3 +37,6 @@ POM_DEVELOPER_ID=okta
 POM_DEVELOPER_NAME=Okta
 
 VERSION_NAME=2.4.0
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-authentication/api/native-authentication.api
+++ b/native-authentication/api/native-authentication.api
@@ -33,6 +33,7 @@ public final class com/okta/nativeauthentication/form/Element$Label$Type : java/
 	public static final field DESCRIPTION Lcom/okta/nativeauthentication/form/Element$Label$Type;
 	public static final field ERROR Lcom/okta/nativeauthentication/form/Element$Label$Type;
 	public static final field HEADER Lcom/okta/nativeauthentication/form/Element$Label$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/nativeauthentication/form/Element$Label$Type;
 	public static fun values ()[Lcom/okta/nativeauthentication/form/Element$Label$Type;
 }

--- a/native-authentication/build.gradle
+++ b/native-authentication/build.gradle
@@ -3,6 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'binary-compatibility-validator'
 
+def copyKotlinTemplates = tasks.register('copyKotlinTemplates', Copy) {
+    from("src/main/kotlinTemplates")
+    into("$buildDir/generated/sources/kotlinTemplates")
+    expand(projectVersion: project.version)
+}
+
 android {
     compileSdkVersion build_versions.compile_sdk
 
@@ -65,12 +71,4 @@ dependencies {
     testImplementation project(':test-utils')
 }
 
-task copyKotlinTemplates(type: Copy) {
-    from("src/main/kotlinTemplates")
-    into("$buildDir/generated/sources/kotlinTemplates")
-    expand(projectVersion: project.version)
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile) {
-    dependsOn(copyKotlinTemplates)
-}
+preBuild.dependsOn(copyKotlinTemplates)

--- a/okta-idx-kotlin/api/okta-idx-kotlin.api
+++ b/okta-idx-kotlin/api/okta-idx-kotlin.api
@@ -61,6 +61,7 @@ public final class com/okta/idx/kotlin/dto/IdxAuthenticator$Kind : java/lang/Enu
 	public static final field SECURITY_KEY Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Kind;
 	public static final field SECURITY_QUESTION Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Kind;
 	public static final field UNKNOWN Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Kind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Kind;
 	public static fun values ()[Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Kind;
 }
@@ -77,6 +78,7 @@ public final class com/okta/idx/kotlin/dto/IdxAuthenticator$Method : java/lang/E
 	public static final field UNKNOWN Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Method;
 	public static final field VOICE Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Method;
 	public static final field WEB_AUTHN Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Method;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Method;
 	public static fun values ()[Lcom/okta/idx/kotlin/dto/IdxAuthenticator$Method;
 }
@@ -87,6 +89,7 @@ public final class com/okta/idx/kotlin/dto/IdxAuthenticator$State : java/lang/En
 	public static final field ENROLLING Lcom/okta/idx/kotlin/dto/IdxAuthenticator$State;
 	public static final field NORMAL Lcom/okta/idx/kotlin/dto/IdxAuthenticator$State;
 	public static final field RECOVERY Lcom/okta/idx/kotlin/dto/IdxAuthenticator$State;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/idx/kotlin/dto/IdxAuthenticator$State;
 	public static fun values ()[Lcom/okta/idx/kotlin/dto/IdxAuthenticator$State;
 }
@@ -164,6 +167,7 @@ public final class com/okta/idx/kotlin/dto/IdxMessage$Severity : java/lang/Enum 
 	public static final field ERROR Lcom/okta/idx/kotlin/dto/IdxMessage$Severity;
 	public static final field INFO Lcom/okta/idx/kotlin/dto/IdxMessage$Severity;
 	public static final field UNKNOWN Lcom/okta/idx/kotlin/dto/IdxMessage$Severity;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/idx/kotlin/dto/IdxMessage$Severity;
 	public static fun values ()[Lcom/okta/idx/kotlin/dto/IdxMessage$Severity;
 }
@@ -327,6 +331,7 @@ public final class com/okta/idx/kotlin/dto/IdxRemediation$Type : java/lang/Enum 
 	public static final field SKIP Lcom/okta/idx/kotlin/dto/IdxRemediation$Type;
 	public static final field UNKNOWN Lcom/okta/idx/kotlin/dto/IdxRemediation$Type;
 	public static final field UNLOCK_ACCOUNT Lcom/okta/idx/kotlin/dto/IdxRemediation$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/idx/kotlin/dto/IdxRemediation$Type;
 	public static fun values ()[Lcom/okta/idx/kotlin/dto/IdxRemediation$Type;
 }
@@ -393,6 +398,7 @@ public final class com/okta/idx/kotlin/dto/IdxResponse$Intent : java/lang/Enum {
 	public static final field ENROLL_NEW_USER Lcom/okta/idx/kotlin/dto/IdxResponse$Intent;
 	public static final field LOGIN Lcom/okta/idx/kotlin/dto/IdxResponse$Intent;
 	public static final field UNKNOWN Lcom/okta/idx/kotlin/dto/IdxResponse$Intent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/okta/idx/kotlin/dto/IdxResponse$Intent;
 	public static fun values ()[Lcom/okta/idx/kotlin/dto/IdxResponse$Intent;
 }

--- a/okta-idx-kotlin/build.gradle
+++ b/okta-idx-kotlin/build.gradle
@@ -5,6 +5,12 @@ apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'binary-compatibility-validator'
 apply plugin: 'com.vanniktech.maven.publish.base'
 
+def copyKotlinTemplates = tasks.register('copyKotlinTemplates', Copy) {
+    from("src/main/kotlinTemplates")
+    into("$buildDir/generated/sources/kotlinTemplates")
+    expand(projectVersion: project.version)
+}
+
 android {
     compileSdkVersion build_versions.compile_sdk
 
@@ -64,12 +70,4 @@ dependencies {
     testImplementation project(':test-utils')
 }
 
-task copyKotlinTemplates(type: Copy) {
-    from("src/main/kotlinTemplates")
-    into("$buildDir/generated/sources/kotlinTemplates")
-    expand(projectVersion: project.version)
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile) {
-    dependsOn(copyKotlinTemplates)
-}
+preBuild.dependsOn(copyKotlinTemplates)

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,18 +1,18 @@
 def versions = [:]
-versions.activity = '1.5.1'
+versions.activity = '1.7.2'
 versions.androidx_test = '1.5.0'
 versions.androidx_test_runner = '1.5.2'
 versions.androidx_test_ext = '1.1.5'
 versions.androidx_test_orchestrator = '1.4.2'
 versions.androidx_text_uiautomator = '2.2.0'
-versions.android_gradle_plugin = '7.4.2'
+versions.android_gradle_plugin = '8.1.2'
 versions.appcompat = '1.4.2'
-versions.auth_foundation = '1.1.5'
-versions.compose = '1.2.1'
+versions.auth_foundation = '1.2.0'
+versions.compose = '1.5.4'
 versions.constraint_layout = '2.1.4'
 versions.core_ktx = '1.8.0'
-versions.coroutines = '1.6.4'
-versions.cucumber_android = '4.10.0'
+versions.coroutines = '1.7.3'
+versions.cucumber_android = '7.14.0'
 versions.desugar_libs = '2.0.3'
 versions.dokka = '1.8.20'
 versions.espresso = '3.5.1'
@@ -21,9 +21,9 @@ versions.gradle_maven_publish = '0.25.2'
 versions.jackson = '2.15.2'
 versions.jsoup = '1.16.1'
 versions.junit = '4.13.2'
-versions.kotlin = '1.7.20'
-versions.kotlin_binary_compatibility = '0.11.0'
-versions.kotlin_serialization = '1.4.0'
+versions.kotlin = '1.9.10'
+versions.kotlin_binary_compatibility = '0.13.2'
+versions.kotlin_serialization = '1.6.0'
 versions.leakcanary = '2.12'
 versions.lifecycle = '2.5.1'
 versions.material = '1.6.1'
@@ -32,9 +32,9 @@ versions.mockito_core = '4.6.1'
 versions.mockito_kotlin = '4.0.0'
 versions.navigation = '2.5.1'
 versions.okhttp = '4.11.0'
-versions.okio = '3.4.0'
-versions.okta_management = '8.2.2'
-versions.robolectric = '4.10.3'
+versions.okio = '3.5.0'
+versions.okta_management = '14.0.0'
+versions.robolectric = '4.11'
 versions.snakeyaml = '2.0'
 versions.spotless = '6.7.0'
 versions.timber = '5.0.1'
@@ -43,8 +43,8 @@ ext.versions = versions
 
 def build_versions = [:]
 build_versions.min_sdk = 21
-build_versions.compile_sdk = 33
-build_versions.target_sdk = 33
+build_versions.compile_sdk = 34
+build_versions.target_sdk = 34
 ext.build_versions = build_versions
 
 def deps = [:]
@@ -175,7 +175,7 @@ static def addRepos(RepositoryHandler handler) {
 }
 
 def forceVersions(ConfigurationContainer configurations) {
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy {
             force deps.jackson_databind // Vulnerability fix: OKTA-614751
         }


### PR DESCRIPTION
This PR updates okta-bom to 1.2.0. This should fix issues with auth-foundation retry logic messing with IDX responses. Other dependencies are updated to address vulns (robolectric), and for general library hygiene