### PR TITLE
Make PasswordSettings.Age nullable

### DIFF
--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxCapability.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxCapability.kt
@@ -192,7 +192,7 @@ class IdxPasswordSettingsCapability internal constructor(
     /** The associated [IdxPasswordSettingsCapability.Complexity] requirements. */
     val complexity: Complexity,
     /** The associated [IdxPasswordSettingsCapability.Age] requirements. */
-    val age: Age,
+    val age: Age? = null,
 ) : IdxAuthenticator.Capability {
     /** The associated password complexity requirements. */
     class Complexity internal constructor(

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/v1/AuthenticatorMiddleware.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/v1/AuthenticatorMiddleware.kt
@@ -151,7 +151,7 @@ private fun Map<String, JsonElement>.toNumberChallengeCapability(): IdxAuthentic
     return IdxNumberChallengeCapability(correctAnswer = correctAnswer.content)
 }
 
-private fun Authenticator.Settings.toIdxPasswordSettings(): IdxAuthenticator.Capability? {
+private fun Authenticator.Settings.toIdxPasswordSettings(): IdxAuthenticator.Capability {
     return IdxPasswordSettingsCapability(
         complexity = IdxPasswordSettingsCapability.Complexity(
             minLength = complexity.minLength,
@@ -162,10 +162,12 @@ private fun Authenticator.Settings.toIdxPasswordSettings(): IdxAuthenticator.Cap
             excludeUsername = complexity.excludeUsername,
             excludeAttributes = complexity.excludeAttributes,
         ),
-        age = IdxPasswordSettingsCapability.Age(
-            minAgeMinutes = age.minAgeMinutes,
-            historyCount = age.historyCount,
-        ),
+        age = age?.let {
+            IdxPasswordSettingsCapability.Age(
+                minAgeMinutes = it.minAgeMinutes,
+                historyCount = it.historyCount,
+            )
+        },
     )
 }
 

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/v1/Responses.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/v1/Responses.kt
@@ -130,7 +130,7 @@ internal data class Authenticator(
     @Serializable
     internal data class Settings(
         val complexity: Complexity,
-        val age: Age,
+        val age: Age? = null,
     ) {
         @Serializable
         internal data class Complexity(

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxResponseTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxResponseTest.kt
@@ -20,7 +20,6 @@ import com.okta.idx.kotlin.dto.v1.Response
 import com.okta.idx.kotlin.dto.v1.toIdxResponse
 import com.okta.idx.kotlin.dto.v1.toJsonContent
 import com.okta.testing.stringFromResources
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import java.util.Locale
@@ -238,8 +237,25 @@ class IdxResponseTest {
         assertThat(capability.complexity.excludeUsername).isEqualTo(true)
         assertThat(capability.complexity.excludeAttributes).isEqualTo(listOf("firstName", "lastName"))
 
-        assertThat(capability.age.minAgeMinutes).isEqualTo(120)
-        assertThat(capability.age.historyCount).isEqualTo(4)
+        assertThat(capability.age!!.minAgeMinutes).isEqualTo(120)
+        assertThat(capability.age!!.historyCount).isEqualTo(4)
+    }
+
+    @Test fun `test password settings without age`() {
+        val idxResponse = getIdxResponse("enroll_password_no_age.json")
+
+        val authenticator = idxResponse.authenticators.current!!
+        val capability = authenticator.capabilities.get<IdxPasswordSettingsCapability>()!!
+
+        assertThat(capability.complexity.minLength).isEqualTo(8)
+        assertThat(capability.complexity.minLowerCase).isEqualTo(1)
+        assertThat(capability.complexity.minUpperCase).isEqualTo(1)
+        assertThat(capability.complexity.minNumber).isEqualTo(1)
+        assertThat(capability.complexity.minSymbol).isEqualTo(1)
+        assertThat(capability.complexity.excludeUsername).isEqualTo(true)
+        assertThat(capability.complexity.excludeAttributes).isEqualTo(listOf("firstName", "lastName"))
+
+        assertThat(capability.age).isNull()
     }
 
     @Test fun testUnlockAccount() {

--- a/okta-idx-kotlin/src/test/resources/dto/enroll_password_no_age.json
+++ b/okta-idx-kotlin/src/test/resources/dto/enroll_password_no_age.json
@@ -1,0 +1,240 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02HMcT50AyBl8w5q_xRebp-AsU_rxQdMWfYL-0GcjN",
+  "expiresAt": "2021-12-07T16:13:27.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "enroll-authenticator",
+        "relatesTo": [
+          "$.currentAuthenticator"
+        ],
+        "href": "https://foo.okta.com/idp/idx/challenge/answer",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "credentials",
+            "type": "object",
+            "form": {
+              "value": [
+                {
+                  "name": "passcode",
+                  "label": "Enter password",
+                  "secret": true
+                }
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02HMcT50AyBl8w5q_xRebp-AsU_rxQdMWfYL-0GcjN",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      },
+      {
+        "rel": [
+          "create-form"
+        ],
+        "name": "select-authenticator-enroll",
+        "href": "https://foo.okta.com/idp/idx/credential/enroll",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "authenticator",
+            "type": "object",
+            "options": [
+              {
+                "label": "Email",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut8foudnhhcca7Q0696",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "email",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[0]"
+              },
+              {
+                "label": "Password",
+                "value": {
+                  "form": {
+                    "value": [
+                      {
+                        "name": "id",
+                        "required": true,
+                        "value": "aut8foudmnnPXi5y8696",
+                        "mutable": false
+                      },
+                      {
+                        "name": "methodType",
+                        "required": false,
+                        "value": "password",
+                        "mutable": false
+                      }
+                    ]
+                  }
+                },
+                "relatesTo": "$.authenticators.value[1]"
+              }
+            ]
+          },
+          {
+            "name": "stateHandle",
+            "required": true,
+            "value": "02HMcT50AyBl8w5q_xRebp-AsU_rxQdMWfYL-0GcjN",
+            "visible": false,
+            "mutable": false
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "currentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "password",
+      "key": "okta_password",
+      "id": "aut8foudmnnPXi5y8696",
+      "displayName": "Password",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ],
+      "settings": {
+        "complexity": {
+          "minLength": 8,
+          "minLowerCase": 1,
+          "minUpperCase": 1,
+          "minNumber": 1,
+          "minSymbol": 1,
+          "excludeUsername": true,
+          "excludeAttributes": [
+            "firstName",
+            "lastName"
+          ]
+        }
+      }
+    }
+  },
+  "authenticators": {
+    "type": "array",
+    "value": [
+      {
+        "type": "email",
+        "key": "okta_email",
+        "id": "aut8foudnhhcca7Q0696",
+        "displayName": "Email",
+        "methods": [
+          {
+            "type": "email"
+          }
+        ]
+      },
+      {
+        "type": "password",
+        "key": "okta_password",
+        "id": "aut8foudmnnPXi5y8696",
+        "displayName": "Password",
+        "methods": [
+          {
+            "type": "password"
+          }
+        ]
+      }
+    ]
+  },
+  "authenticatorEnrollments": {
+    "type": "array",
+    "value": []
+  },
+  "enrollmentAuthenticator": {
+    "type": "object",
+    "value": {
+      "type": "password",
+      "key": "okta_password",
+      "id": "aut8foudmnnPXi5y8696",
+      "displayName": "Password",
+      "methods": [
+        {
+          "type": "password"
+        }
+      ],
+      "settings": {
+        "complexity": {
+          "minLength": 8,
+          "minLowerCase": 0,
+          "minUpperCase": 0,
+          "minNumber": 0,
+          "minSymbol": 0,
+          "excludeUsername": false,
+          "excludeAttributes": []
+        }
+      }
+    }
+  },
+  "user": {
+    "type": "object",
+    "value": {
+      "id": "00u93b7shLIv4V92a696",
+      "identifier": "jaynewstrom+pass@gmail.com",
+      "profile": {
+        "firstName": "jay",
+        "lastName": "newstrom",
+        "timeZone": "America/Los_Angeles",
+        "locale": "en_US"
+      }
+    }
+  },
+  "cancel": {
+    "rel": [
+      "create-form"
+    ],
+    "name": "cancel",
+    "href": "https://foo.okta.com/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02HMcT50AyBl8w5q_xRebp-AsU_rxQdMWfYL-0GcjN",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  },
+  "app": {
+    "type": "object",
+    "value": {
+      "name": "oidc_client",
+      "label": "Sample",
+      "id": "0oa8fup0lAPYFC4I2696"
+    }
+  }
+}


### PR DESCRIPTION
This field is consumed by clients, and never passed back in a server request. In passwordless scenarios, it can be nullable. This should fix #196 