### PR TITLE
Update authfoundation to version 2

### DIFF
--- a/dynamic-app/build.gradle
+++ b/dynamic-app/build.gradle
@@ -77,7 +77,6 @@ dependencies {
     implementation project(':okta-idx-kotlin')
 
 
-    implementation deps.okta.auth_foundation_bootstrap
     implementation deps.kotlin.stdlib
     implementation deps.core_ktx
     implementation deps.app_compat

--- a/dynamic-app/src/main/java/com/okta/idx/android/SampleCredentialHelper.kt
+++ b/dynamic-app/src/main/java/com/okta/idx/android/SampleCredentialHelper.kt
@@ -16,26 +16,17 @@
 package com.okta.idx.android
 
 import android.content.Context
-import com.okta.authfoundation.AuthFoundationDefaults
-import com.okta.authfoundation.client.OidcClient
+import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.OidcConfiguration
-import com.okta.authfoundation.client.SharedPreferencesCache
-import com.okta.authfoundation.credential.CredentialDataSource.Companion.createCredentialDataSource
-import com.okta.authfoundationbootstrap.CredentialBootstrap
 import com.okta.idx.android.dynamic.BuildConfig
-import okhttp3.HttpUrl.Companion.toHttpUrl
 
 internal object SampleCredentialHelper {
     fun initialize(context: Context) {
-        AuthFoundationDefaults.cache = SharedPreferencesCache.create(context)
-        val oidcConfiguration = OidcConfiguration(
+        OidcConfiguration.default = OidcConfiguration(
+            issuer = BuildConfig.ISSUER,
             clientId = BuildConfig.CLIENT_ID,
             defaultScope = "openid email profile offline_access",
         )
-        val oidcClient = OidcClient.createFromDiscoveryUrl(
-            oidcConfiguration,
-            "${BuildConfig.ISSUER}/.well-known/openid-configuration".toHttpUrl(),
-        )
-        CredentialBootstrap.initialize(oidcClient.createCredentialDataSource(context))
+        AuthFoundation.initializeAndroidContext(context)
     }
 }

--- a/dynamic-app/src/main/java/com/okta/idx/android/dashboard/DashboardFragment.kt
+++ b/dynamic-app/src/main/java/com/okta/idx/android/dashboard/DashboardFragment.kt
@@ -21,7 +21,7 @@ import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.okta.authfoundationbootstrap.CredentialBootstrap
+import com.okta.authfoundation.credential.Credential
 import com.okta.idx.android.dynamic.R
 import com.okta.idx.android.dynamic.databinding.FragmentDashboardBinding
 import com.okta.idx.android.dynamic.databinding.RowDashboardClaimBinding
@@ -36,7 +36,7 @@ internal class DashboardFragment : BaseFragment<FragmentDashboardBinding>(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         lifecycleScope.launch {
-            CredentialBootstrap.defaultCredential().token?.let { token ->
+            Credential.default?.token?.let { token ->
                 binding.tokenType.text = token.tokenType
                 binding.expiresIn.text = token.expiresIn.toString()
                 binding.accessToken.text = token.accessToken

--- a/dynamic-app/src/main/java/com/okta/idx/android/dynamic/auth/DynamicAuthViewModel.kt
+++ b/dynamic-app/src/main/java/com/okta/idx/android/dynamic/auth/DynamicAuthViewModel.kt
@@ -72,10 +72,11 @@ internal class DynamicAuthViewModel(private val recoveryToken: String) : ViewMod
             if (recoveryToken.isNotEmpty()) {
                 extraRequestParameters["recovery_token"] = recoveryToken
             }
+            val interactionCodeFlow = InteractionCodeFlow()
             // Initiate the IDX client and start IDX flow.
             when (
-                val clientResult = InteractionCodeFlow.create(
-                    redirectUrl = BuildConfig.REDIRECT_URI,
+                val clientResult = interactionCodeFlow.start(
+                    redirectUri = Uri.parse(BuildConfig.REDIRECT_URI),
                     extraStartRequestParameters = extraRequestParameters,
                 )
             ) {
@@ -84,9 +85,9 @@ internal class DynamicAuthViewModel(private val recoveryToken: String) : ViewMod
                     _state.value = DynamicAuthState.Error("Failed to create client")
                 }
                 is OAuth2ClientResult.Success -> {
-                    flow = clientResult.result
+                    flow = interactionCodeFlow
                     // Call the IDX API's resume method to receive the first IDX response.
-                    when (val resumeResult = clientResult.result.resume()) {
+                    when (val resumeResult = interactionCodeFlow.resume()) {
                         is OAuth2ClientResult.Error -> {
                             _state.value = DynamicAuthState.Error("Failed to call resume")
                         }

--- a/native-authentication/src/main/java/com/okta/nativeauthentication/IdxResponseTransformer.kt
+++ b/native-authentication/src/main/java/com/okta/nativeauthentication/IdxResponseTransformer.kt
@@ -15,7 +15,7 @@
  */
 package com.okta.nativeauthentication
 
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxAuthenticator
 import com.okta.idx.kotlin.dto.IdxAuthenticatorCollection
@@ -32,7 +32,7 @@ import com.okta.nativeauthentication.form.Form
 
 internal interface IdxResponseTransformer {
     fun transform(
-        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OidcClientResult<IdxResponse>) -> Unit,
+        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OAuth2ClientResult<IdxResponse>) -> Unit,
         response: IdxResponse,
         clickHandler: (IdxRemediation, Form) -> Unit,
     ): Form.Builder
@@ -40,7 +40,7 @@ internal interface IdxResponseTransformer {
 
 internal class RealIdxResponseTransformer : IdxResponseTransformer {
     override fun transform(
-        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OidcClientResult<IdxResponse>) -> Unit,
+        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OAuth2ClientResult<IdxResponse>) -> Unit,
         response: IdxResponse,
         clickHandler: (IdxRemediation, Form) -> Unit,
     ): Form.Builder {
@@ -191,7 +191,7 @@ internal class RealIdxResponseTransformer : IdxResponseTransformer {
     }
 
     private fun IdxRemediation.pollingAction(
-        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OidcClientResult<IdxResponse>) -> Unit,
+        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OAuth2ClientResult<IdxResponse>) -> Unit,
     ): (suspend () -> Unit)? {
         val remediationCapability = capabilities.get<IdxPollRemediationCapability>()
         val authenticatorCapability = authenticators.capability<IdxPollAuthenticatorCapability>()

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/NativeAuthenticationClientTest.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/NativeAuthenticationClientTest.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.nativeauthentication
 
+import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.authfoundation.credential.Token
@@ -37,11 +38,14 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
+@RunWith(RobolectricTestRunner::class)
 class NativeAuthenticationClientTest {
     @get:Rule val networkRule = NetworkRule()
 
@@ -67,7 +71,9 @@ class NativeAuthenticationClientTest {
         fakeCallback = FakeCallback()
         fakeIdxResponseTransformer = FakeIdxResponseTransformer()
         return NativeAuthenticationClient(emptyList(), fakeIdxResponseTransformer).create(fakeCallback) {
-            InteractionCodeFlow.create("test.okta.com/login")
+            val flow = InteractionCodeFlow()
+            flow.start(Uri.parse("test.okta.com/login"))
+            flow
         }
     }
 
@@ -136,30 +142,6 @@ class NativeAuthenticationClientTest {
         // Implicitly ensuring this doesn't throw or cause another request.
         assertThat((formReference.get().elements[0] as Element.Label).text).isEqualTo("Fake Label")
         (formReference.get().elements[2] as Element.Action).onClick(formReference.get())
-    }
-
-    @Test fun testFailedInteractCallRetriesInteract(): Unit = runBlocking {
-        networkRule.enqueue(path("/idp/idx/introspect")) { response ->
-            response.testBodyFromFile("IdentifyRemediationResponse.json")
-        }
-        val flow = setup(::enqueueInteractFailure)
-        val formCounter = AtomicInteger()
-        val forms = flow.take(4).onEach { form ->
-            if (formCounter.getAndIncrement() == 1) {
-                enqueueInteractSuccess()
-                (form.elements[0] as Element.Action).onClick(form)
-            }
-        }.toList()
-        assertThat(forms[0].elements).hasSize(1)
-        assertThat((forms[0].elements[0])).isInstanceOf(Element.Loading::class.java)
-        assertThat(forms[1].elements).hasSize(1)
-        assertThat((forms[1].elements[0] as Element.Action).text).isEqualTo("Retry")
-        assertThat(forms[2].elements).hasSize(1)
-        assertThat((forms[2].elements[0])).isInstanceOf(Element.Loading::class.java)
-        assertThat(forms[3].elements).hasSize(3)
-        assertThat((forms[3].elements[0] as Element.Label).text).isEqualTo("Fake Label")
-        assertThat((forms[3].elements[1] as Element.TextInput).label).isEqualTo("Fake Text Input")
-        assertThat((forms[3].elements[2] as Element.Action).text).isEqualTo("Fake Button")
     }
 
     @Test fun testFailedIntrospectCallRetriesIntrospect(): Unit = runBlocking {

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/NativeAuthenticationClientTest.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/NativeAuthenticationClientTest.kt
@@ -16,10 +16,9 @@
 package com.okta.nativeauthentication
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.authfoundation.credential.Token
 import com.okta.idx.kotlin.client.InteractionCodeFlow
-import com.okta.idx.kotlin.client.InteractionCodeFlow.Companion.createInteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxRemediation
 import com.okta.idx.kotlin.dto.IdxResponse
 import com.okta.nativeauthentication.form.Element
@@ -66,10 +65,9 @@ class NativeAuthenticationClientTest {
     ): Flow<Form> {
         interactResponseFactory()
         fakeCallback = FakeCallback()
-        val oidcClient = networkRule.createOidcClient()
         fakeIdxResponseTransformer = FakeIdxResponseTransformer()
         return NativeAuthenticationClient(emptyList(), fakeIdxResponseTransformer).create(fakeCallback) {
-            oidcClient.createInteractionCodeFlow("test.okta.com/login")
+            InteractionCodeFlow.create("test.okta.com/login")
         }
     }
 
@@ -287,7 +285,7 @@ private class FakeIdxResponseTransformer : IdxResponseTransformer {
     var makeTextInputRequired = false
 
     override fun transform(
-        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OidcClientResult<IdxResponse>) -> Unit,
+        resultHandler: suspend (resultProducer: suspend (InteractionCodeFlow) -> OAuth2ClientResult<IdxResponse>) -> Unit,
         response: IdxResponse,
         clickHandler: (IdxRemediation, Form) -> Unit
     ): Form.Builder {

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/RealIdxResponseTransformerTest.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/RealIdxResponseTransformerTest.kt
@@ -26,9 +26,12 @@ import com.okta.testing.network.NetworkRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
+@RunWith(RobolectricTestRunner::class)
 internal class RealIdxResponseTransformerTest {
     @get:Rule val networkRule = NetworkRule()
 

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/RealIdxResponseTransformerTest.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/RealIdxResponseTransformerTest.kt
@@ -16,7 +16,7 @@
 package com.okta.nativeauthentication
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxRemediation
 import com.okta.idx.kotlin.dto.IdxResponse
@@ -35,7 +35,7 @@ internal class RealIdxResponseTransformerTest {
     private val idxResponseFactory = IdxResponseFactory(networkRule)
 
     private val noInteractionsResponseTransformer: suspend (
-        resultProducer: suspend (InteractionCodeFlow) -> OidcClientResult<IdxResponse>
+        resultProducer: suspend (InteractionCodeFlow) -> OAuth2ClientResult<IdxResponse>
     ) -> Unit = {
         throw AssertionError("Not expected")
     }

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/form/transformer/SignInTitleTransformerTest.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/form/transformer/SignInTitleTransformerTest.kt
@@ -16,7 +16,7 @@
 package com.okta.nativeauthentication.form.transformer
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxResponse
 import com.okta.nativeauthentication.RealIdxResponseTransformer
@@ -34,7 +34,7 @@ internal class SignInTitleTransformerTest {
     private val idxResponseFactory = IdxResponseFactory(networkRule)
 
     private fun getFormFromJson(json: String): Form = runBlocking {
-        val responseTransformer: suspend (resultProducer: suspend (InteractionCodeFlow) -> OidcClientResult<IdxResponse>) -> Unit = {
+        val responseTransformer: suspend (resultProducer: suspend (InteractionCodeFlow) -> OAuth2ClientResult<IdxResponse>) -> Unit = {
             throw AssertionError("Not expected")
         }
         val formBuilder = RealIdxResponseTransformer().transform(responseTransformer, idxResponseFactory.fromJson(json)) { _, _ -> }

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/form/transformer/SignInTitleTransformerTest.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/form/transformer/SignInTitleTransformerTest.kt
@@ -27,7 +27,10 @@ import com.okta.testing.network.NetworkRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 internal class SignInTitleTransformerTest {
     @get:Rule val networkRule = NetworkRule()
 

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/utils/IdxResponseFactory.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/utils/IdxResponseFactory.kt
@@ -15,9 +15,8 @@
  */
 package com.okta.nativeauthentication.utils
 
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
-import com.okta.idx.kotlin.client.InteractionCodeFlow.Companion.createInteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxResponse
 import com.okta.testing.network.NetworkRule
 import com.okta.testing.network.RequestMatchers.path
@@ -32,9 +31,8 @@ internal class IdxResponseFactory(private val networkRule: NetworkRule) {
         networkRule.enqueue(path("/idp/idx/introspect")) { response ->
             response.setBody(json)
         }
-        val oidcClient = networkRule.createOidcClient()
-        val interactionCodeFlowResult = oidcClient.createInteractionCodeFlow("test.okta.com/login")
-        val interactionCodeFlow = (interactionCodeFlowResult as OidcClientResult.Success<InteractionCodeFlow>).result
-        (interactionCodeFlow.resume() as OidcClientResult.Success<IdxResponse>).result
+        val interactionCodeFlowResult = InteractionCodeFlow.create("test.okta.com/login")
+        val interactionCodeFlow = (interactionCodeFlowResult as OAuth2ClientResult.Success<InteractionCodeFlow>).result
+        (interactionCodeFlow.resume() as OAuth2ClientResult.Success<IdxResponse>).result
     }
 }

--- a/native-authentication/src/test/java/com/okta/nativeauthentication/utils/IdxResponseFactory.kt
+++ b/native-authentication/src/test/java/com/okta/nativeauthentication/utils/IdxResponseFactory.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.nativeauthentication.utils
 
+import android.net.Uri
 import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxResponse
@@ -31,8 +32,7 @@ internal class IdxResponseFactory(private val networkRule: NetworkRule) {
         networkRule.enqueue(path("/idp/idx/introspect")) { response ->
             response.setBody(json)
         }
-        val interactionCodeFlowResult = InteractionCodeFlow.create("test.okta.com/login")
-        val interactionCodeFlow = (interactionCodeFlowResult as OAuth2ClientResult.Success<InteractionCodeFlow>).result
+        val interactionCodeFlow = InteractionCodeFlow().apply { start(Uri.parse("test.okta.com/login")) }
         (interactionCodeFlow.resume() as OAuth2ClientResult.Success<IdxResponse>).result
     }
 }

--- a/okta-idx-kotlin/api/okta-idx-kotlin.api
+++ b/okta-idx-kotlin/api/okta-idx-kotlin.api
@@ -16,16 +16,18 @@ public final class com/okta/idx/kotlin/client/IdxRedirectResult$Tokens : com/okt
 
 public final class com/okta/idx/kotlin/client/InteractionCodeFlow {
 	public static final field Companion Lcom/okta/idx/kotlin/client/InteractionCodeFlow$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun evaluateRedirectUri (Landroid/net/Uri;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun exchangeInteractionCodeForTokens (Lcom/okta/idx/kotlin/dto/IdxRemediation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getFlowContext ()Lcom/okta/idx/kotlin/client/InteractionCodeFlowContext;
 	public final fun proceed (Lcom/okta/idx/kotlin/dto/IdxRemediation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun resume (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Landroid/net/Uri;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start$default (Lcom/okta/idx/kotlin/client/InteractionCodeFlow;Landroid/net/Uri;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/idx/kotlin/client/InteractionCodeFlow$Companion {
-	public final fun create (Ljava/lang/String;Ljava/util/Map;Lcom/okta/authfoundation/client/OAuth2Client;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun create$default (Lcom/okta/idx/kotlin/client/InteractionCodeFlow$Companion;Ljava/lang/String;Ljava/util/Map;Lcom/okta/authfoundation/client/OAuth2Client;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/idx/kotlin/client/InteractionCodeFlowContext {

--- a/okta-idx-kotlin/api/okta-idx-kotlin.api
+++ b/okta-idx-kotlin/api/okta-idx-kotlin.api
@@ -24,8 +24,8 @@ public final class com/okta/idx/kotlin/client/InteractionCodeFlow {
 }
 
 public final class com/okta/idx/kotlin/client/InteractionCodeFlow$Companion {
-	public final fun createInteractionCodeFlow (Lcom/okta/authfoundation/client/OidcClient;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun createInteractionCodeFlow$default (Lcom/okta/idx/kotlin/client/InteractionCodeFlow$Companion;Lcom/okta/authfoundation/client/OidcClient;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun create (Ljava/lang/String;Ljava/util/Map;Lcom/okta/authfoundation/client/OAuth2Client;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun create$default (Lcom/okta/idx/kotlin/client/InteractionCodeFlow$Companion;Ljava/lang/String;Ljava/util/Map;Lcom/okta/authfoundation/client/OAuth2Client;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/idx/kotlin/client/InteractionCodeFlowContext {

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxCapability.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxCapability.kt
@@ -17,7 +17,7 @@ package com.okta.idx.kotlin.dto
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxRemediation.Type
 import kotlinx.coroutines.delay
@@ -65,19 +65,19 @@ class IdxPollRemediationCapability internal constructor(
      *
      * All polling delay/retry logic is handled internally.
      *
-     * @return the [OidcClientResult] when the state changes.
+     * @return the [OAuth2ClientResult] when the state changes.
      */
-    suspend fun poll(flow: InteractionCodeFlow): OidcClientResult<IdxResponse> {
-        var result: OidcClientResult<IdxResponse>
+    suspend fun poll(flow: InteractionCodeFlow): OAuth2ClientResult<IdxResponse> {
+        var result: OAuth2ClientResult<IdxResponse>
         var currentWait = wait
         var currentRemediation = remediation
         do {
             delayFunction(currentWait.toLong())
             result = flow.proceed(currentRemediation)
-            if (result is OidcClientResult.Error) {
+            if (result is OAuth2ClientResult.Error) {
                 return result
             }
-            val successResult = result as? OidcClientResult.Success<IdxResponse>
+            val successResult = result as? OAuth2ClientResult.Success<IdxResponse>
             val remediations = successResult?.result?.remediations ?: return result
 
             var pollCapability: IdxPollRemediationCapability? = null
@@ -136,20 +136,20 @@ class IdxPollAuthenticatorCapability internal constructor(
      *
      * All polling delay/retry logic is handled internally.
      *
-     * @return the [OidcClientResult] when the state changes.
+     * @return the [OAuth2ClientResult] when the state changes.
      */
-    suspend fun poll(flow: InteractionCodeFlow): OidcClientResult<IdxResponse> {
-        var result: OidcClientResult<IdxResponse>
+    suspend fun poll(flow: InteractionCodeFlow): OAuth2ClientResult<IdxResponse> {
+        var result: OAuth2ClientResult<IdxResponse>
         var currentAuthenticatorId: String?
         var currentWait = wait
         var currentRemediation = remediation
         do {
             delayFunction(currentWait.toLong())
             result = flow.proceed(currentRemediation)
-            if (result is OidcClientResult.Error) {
+            if (result is OAuth2ClientResult.Error) {
                 return result
             }
-            val successResult = result as? OidcClientResult.Success<IdxResponse>
+            val successResult = result as? OAuth2ClientResult.Success<IdxResponse>
             val currentAuthenticator = successResult?.result?.authenticators?.current ?: return result
             currentAuthenticatorId = currentAuthenticator.id
             val pollCapability = currentAuthenticator.capabilities.get<IdxPollAuthenticatorCapability>() ?: return result

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/IdxRedirectResultTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/IdxRedirectResultTest.kt
@@ -41,7 +41,9 @@ class IdxRedirectResultTest {
             nonce = "defg",
             maxAge = maxAge
         )
-        return InteractionCodeFlow(networkRule.createClient(), flowContext)
+        return InteractionCodeFlow(networkRule.createClient()).apply {
+            this.flowContext = flowContext
+        }
     }
 
     @Test fun testRedirectResultInvalidUrl(): Unit = runBlocking {

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/IdxRedirectResultTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/IdxRedirectResultTest.kt
@@ -41,7 +41,7 @@ class IdxRedirectResultTest {
             nonce = "defg",
             maxAge = maxAge
         )
-        return InteractionCodeFlow(networkRule.createOidcClient(), flowContext)
+        return InteractionCodeFlow(networkRule.createClient(), flowContext)
     }
 
     @Test fun testRedirectResultInvalidUrl(): Unit = runBlocking {

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/InteractionCodeFlowTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/InteractionCodeFlowTest.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.idx.kotlin.client
 
+import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.client.OAuth2Client
 import com.okta.authfoundation.client.OAuth2ClientResult
@@ -31,17 +32,23 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class InteractionCodeFlowTest {
     @get:Rule val networkRule = NetworkRule()
+
+    private val testUri = Uri.parse("test.okta.com/login")
 
     @Test fun testStart(): Unit = runBlocking {
         networkRule.enqueue(path("/oauth2/default/v1/interact")) { response ->
             response.testBodyFromFile("client/interactResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        assertThat(clientResult.result.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow()
+        flow.start(testUri)
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
     }
 
     @Test fun testStartWithNoEndpoints(): Unit = runBlocking {
@@ -50,7 +57,8 @@ class InteractionCodeFlowTest {
         }
 
         val client = OAuth2Client.createFromConfiguration(networkRule.configuration)
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login", client = client) as OAuth2ClientResult.Error<InteractionCodeFlow>
+        val flow = InteractionCodeFlow(client = client)
+        val clientResult = flow.start(testUri) as OAuth2ClientResult.Error<Unit>
         assertThat(clientResult.exception).isInstanceOf(OAuth2ClientResult.Error.OidcEndpointsNotAvailableException::class.java)
     }
 
@@ -63,8 +71,8 @@ class InteractionCodeFlowTest {
         }
 
         val extraParameters = mapOf(Pair("recovery_token", "secret123"))
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login", extraParameters) as OAuth2ClientResult.Success<InteractionCodeFlow>
-        assertThat(clientResult.result.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri, extraParameters) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
     }
 
     @Test fun testResume(): Unit = runBlocking {
@@ -76,11 +84,10 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         assertThat(resumeResult.result.remediations).hasSize(4)
     }
 
@@ -96,18 +103,17 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/successWithInteractionCodeResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
+        val proceedResult = flow.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         assertThat(proceedResult.result.remediations[1].type).isEqualTo(IdxRemediation.Type.ISSUE)
     }
 
@@ -123,18 +129,17 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
+        val proceedResult = flow.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         val newIdentifyRemediation = proceedResult.result.remediations[0]
         assertThat(newIdentifyRemediation["identifier"]?.value).isEqualTo("test@okta.com")
         assertThat(newIdentifyRemediation["credentials.passcode"]?.value).isEqualTo("example")
@@ -154,25 +159,24 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/tokenResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
+        val proceedResult = flow.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         val proceedResponse = proceedResult.result
         val issueRemediation = proceedResponse.remediations[1]
         assertThat(issueRemediation.type).isEqualTo(IdxRemediation.Type.ISSUE)
 
-        val tokenResult = client.exchangeInteractionCodeForTokens(issueRemediation) as OAuth2ClientResult.Success<Token>
+        val tokenResult = flow.exchangeInteractionCodeForTokens(issueRemediation) as OAuth2ClientResult.Success<Token>
         assertThat(tokenResult.result.accessToken).isEqualTo("eyJraWQiOiJBaE1qU3VMQWdBTDJ1dHVVY2lFRWJ2R1JUbi1GRkt1Y2tVTDJibVZMVmp3IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULm01N1NsVUpMRUQyT1RtLXVrUFBEVGxFY0tialFvYy1wVGxVdm5ha0k3T1Eub2FyNjFvOHVVOVlGVnBYcjYybzQiLCJpc3MiOiJodHRwczovL2Zvby5wcmV2aWV3LmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2MDg1NjcwMTgsImV4cCI6MTYwODU3MDYxOCwiY2lkIjoiMG9henNtcHhacFZFZzRjaFMybzQiLCJ1aWQiOiIwMHUxMGt2dkZDMDZHT21odTJvNSIsInNjcCI6WyJvcGVuaWQiLCJwcm9maWxlIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoiZm9vQG9rdGEuY29tIn0.lg2T8dKVfic_JU6qzNBqDuw3RFUq7Da5UO37eY3W-cOOb9UqijxGYj7d-z8qK1UJjRRcDg-rTMzYQbKCLVxjBw")
-        assertThat(networkRule.idTokenValidator.lastIdTokenParameters.nonce).isEqualTo(client.flowContext.nonce)
+        assertThat(networkRule.idTokenValidator.lastIdTokenParameters.nonce).isEqualTo(flow.flowContext.nonce)
         assertThat(networkRule.idTokenValidator.lastIdTokenParameters.maxAge).isNull()
     }
 
@@ -191,28 +195,24 @@ class InteractionCodeFlowTest {
         }
 
         val extraParameters = mapOf("max_age" to "65")
-        val clientResult = InteractionCodeFlow.create(
-            redirectUrl = "test.okta.com/login",
-            extraStartRequestParameters = extraParameters,
-        ) as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri, extraParameters) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
+        val proceedResult = flow.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         val proceedResponse = proceedResult.result
         val issueRemediation = proceedResponse.remediations[1]
         assertThat(issueRemediation.type).isEqualTo(IdxRemediation.Type.ISSUE)
 
-        val tokenResult = client.exchangeInteractionCodeForTokens(issueRemediation) as OAuth2ClientResult.Success<Token>
+        val tokenResult = flow.exchangeInteractionCodeForTokens(issueRemediation) as OAuth2ClientResult.Success<Token>
         assertThat(tokenResult.result.accessToken).isEqualTo("eyJraWQiOiJBaE1qU3VMQWdBTDJ1dHVVY2lFRWJ2R1JUbi1GRkt1Y2tVTDJibVZMVmp3IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULm01N1NsVUpMRUQyT1RtLXVrUFBEVGxFY0tialFvYy1wVGxVdm5ha0k3T1Eub2FyNjFvOHVVOVlGVnBYcjYybzQiLCJpc3MiOiJodHRwczovL2Zvby5wcmV2aWV3LmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2MDg1NjcwMTgsImV4cCI6MTYwODU3MDYxOCwiY2lkIjoiMG9henNtcHhacFZFZzRjaFMybzQiLCJ1aWQiOiIwMHUxMGt2dkZDMDZHT21odTJvNSIsInNjcCI6WyJvcGVuaWQiLCJwcm9maWxlIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoiZm9vQG9rdGEuY29tIn0.lg2T8dKVfic_JU6qzNBqDuw3RFUq7Da5UO37eY3W-cOOb9UqijxGYj7d-z8qK1UJjRRcDg-rTMzYQbKCLVxjBw")
-        assertThat(networkRule.idTokenValidator.lastIdTokenParameters.nonce).isEqualTo(client.flowContext.nonce)
+        assertThat(networkRule.idTokenValidator.lastIdTokenParameters.nonce).isEqualTo(flow.flowContext.nonce)
         assertThat(networkRule.idTokenValidator.lastIdTokenParameters.maxAge).isEqualTo(65)
     }
 
@@ -221,11 +221,10 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/interactResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        assertThat(clientResult.result.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val client = clientResult.result
-        val exchangeCodesResult = client.exchangeInteractionCodeForTokens(createRemediation(emptyList())) as OAuth2ClientResult.Error<Token>
+        val exchangeCodesResult = flow.exchangeInteractionCodeForTokens(createRemediation(emptyList())) as OAuth2ClientResult.Error<Token>
         assertThat(exchangeCodesResult.exception.message).isEqualTo("Invalid remediation.")
     }
 
@@ -239,11 +238,10 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json").setResponseCode(499)
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         assertThat(resumeResult.result.remediations).hasSize(4)
     }
 
@@ -257,11 +255,10 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json").setResponseCode(500)
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        assertThat(flow.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OAuth2ClientResult.Error<IdxResponse>
+        val resumeResult = flow.resume() as OAuth2ClientResult.Error<IdxResponse>
         assertThat(resumeResult.exception.message).isEqualTo("HTTP Error: status code - 500")
     }
 }

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/InteractionCodeFlowTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/client/InteractionCodeFlowTest.kt
@@ -16,10 +16,9 @@
 package com.okta.idx.kotlin.client
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClient
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2Client
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.authfoundation.credential.Token
-import com.okta.idx.kotlin.client.InteractionCodeFlow.Companion.createInteractionCodeFlow
 import com.okta.idx.kotlin.dto.IdxRemediation
 import com.okta.idx.kotlin.dto.IdxResponse
 import com.okta.idx.kotlin.dto.createRemediation
@@ -41,7 +40,7 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/interactResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         assertThat(clientResult.result.flowContext.interactionHandle).isEqualTo("029ZAB")
     }
 
@@ -50,13 +49,9 @@ class InteractionCodeFlowTest {
             response.socketPolicy = SocketPolicy.DISCONNECT_AT_START
         }
 
-        val oidcClient = OidcClient.createFromDiscoveryUrl(
-            networkRule.configuration,
-            networkRule.mockedUrl().newBuilder()
-                .addPathSegments(".well-known/openid-configuration").build(),
-        )
-        val clientResult = oidcClient.createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Error<InteractionCodeFlow>
-        assertThat(clientResult.exception).isInstanceOf(OidcClientResult.Error.OidcEndpointsNotAvailableException::class.java)
+        val client = OAuth2Client.createFromConfiguration(networkRule.configuration)
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login", client = client) as OAuth2ClientResult.Error<InteractionCodeFlow>
+        assertThat(clientResult.exception).isInstanceOf(OAuth2ClientResult.Error.OidcEndpointsNotAvailableException::class.java)
     }
 
     @Test fun testStartWithExtraParameters(): Unit = runBlocking {
@@ -68,7 +63,7 @@ class InteractionCodeFlowTest {
         }
 
         val extraParameters = mapOf(Pair("recovery_token", "secret123"))
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login", extraParameters) as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login", extraParameters) as OAuth2ClientResult.Success<InteractionCodeFlow>
         assertThat(clientResult.result.flowContext.interactionHandle).isEqualTo("029ZAB")
     }
 
@@ -81,11 +76,11 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         assertThat(resumeResult.result.remediations).hasSize(4)
     }
 
@@ -101,18 +96,18 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/successWithInteractionCodeResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OidcClientResult.Success<IdxResponse>
+        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         assertThat(proceedResult.result.remediations[1].type).isEqualTo(IdxRemediation.Type.ISSUE)
     }
 
@@ -128,18 +123,18 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OidcClientResult.Success<IdxResponse>
+        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         val newIdentifyRemediation = proceedResult.result.remediations[0]
         assertThat(newIdentifyRemediation["identifier"]?.value).isEqualTo("test@okta.com")
         assertThat(newIdentifyRemediation["credentials.passcode"]?.value).isEqualTo("example")
@@ -159,23 +154,23 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/tokenResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OidcClientResult.Success<IdxResponse>
+        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         val proceedResponse = proceedResult.result
         val issueRemediation = proceedResponse.remediations[1]
         assertThat(issueRemediation.type).isEqualTo(IdxRemediation.Type.ISSUE)
 
-        val tokenResult = client.exchangeInteractionCodeForTokens(issueRemediation) as OidcClientResult.Success<Token>
+        val tokenResult = client.exchangeInteractionCodeForTokens(issueRemediation) as OAuth2ClientResult.Success<Token>
         assertThat(tokenResult.result.accessToken).isEqualTo("eyJraWQiOiJBaE1qU3VMQWdBTDJ1dHVVY2lFRWJ2R1JUbi1GRkt1Y2tVTDJibVZMVmp3IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULm01N1NsVUpMRUQyT1RtLXVrUFBEVGxFY0tialFvYy1wVGxVdm5ha0k3T1Eub2FyNjFvOHVVOVlGVnBYcjYybzQiLCJpc3MiOiJodHRwczovL2Zvby5wcmV2aWV3LmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2MDg1NjcwMTgsImV4cCI6MTYwODU3MDYxOCwiY2lkIjoiMG9henNtcHhacFZFZzRjaFMybzQiLCJ1aWQiOiIwMHUxMGt2dkZDMDZHT21odTJvNSIsInNjcCI6WyJvcGVuaWQiLCJwcm9maWxlIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoiZm9vQG9rdGEuY29tIn0.lg2T8dKVfic_JU6qzNBqDuw3RFUq7Da5UO37eY3W-cOOb9UqijxGYj7d-z8qK1UJjRRcDg-rTMzYQbKCLVxjBw")
         assertThat(networkRule.idTokenValidator.lastIdTokenParameters.nonce).isEqualTo(client.flowContext.nonce)
         assertThat(networkRule.idTokenValidator.lastIdTokenParameters.maxAge).isNull()
@@ -196,26 +191,26 @@ class InteractionCodeFlowTest {
         }
 
         val extraParameters = mapOf("max_age" to "65")
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow(
+        val clientResult = InteractionCodeFlow.create(
             redirectUrl = "test.okta.com/login",
             extraStartRequestParameters = extraParameters,
-        ) as OidcClientResult.Success<InteractionCodeFlow>
+        ) as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
         assertThat(resumeResponse.remediations).hasSize(4)
 
         val identifyRemediation = resumeResponse.remediations[0]
         identifyRemediation["identifier"]?.value = "test@okta.com"
         identifyRemediation["credentials.passcode"]?.value = "example"
-        val proceedResult = client.proceed(identifyRemediation) as OidcClientResult.Success<IdxResponse>
+        val proceedResult = client.proceed(identifyRemediation) as OAuth2ClientResult.Success<IdxResponse>
         val proceedResponse = proceedResult.result
         val issueRemediation = proceedResponse.remediations[1]
         assertThat(issueRemediation.type).isEqualTo(IdxRemediation.Type.ISSUE)
 
-        val tokenResult = client.exchangeInteractionCodeForTokens(issueRemediation) as OidcClientResult.Success<Token>
+        val tokenResult = client.exchangeInteractionCodeForTokens(issueRemediation) as OAuth2ClientResult.Success<Token>
         assertThat(tokenResult.result.accessToken).isEqualTo("eyJraWQiOiJBaE1qU3VMQWdBTDJ1dHVVY2lFRWJ2R1JUbi1GRkt1Y2tVTDJibVZMVmp3IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULm01N1NsVUpMRUQyT1RtLXVrUFBEVGxFY0tialFvYy1wVGxVdm5ha0k3T1Eub2FyNjFvOHVVOVlGVnBYcjYybzQiLCJpc3MiOiJodHRwczovL2Zvby5wcmV2aWV3LmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6ImFwaTovL2RlZmF1bHQiLCJpYXQiOjE2MDg1NjcwMTgsImV4cCI6MTYwODU3MDYxOCwiY2lkIjoiMG9henNtcHhacFZFZzRjaFMybzQiLCJ1aWQiOiIwMHUxMGt2dkZDMDZHT21odTJvNSIsInNjcCI6WyJvcGVuaWQiLCJwcm9maWxlIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoiZm9vQG9rdGEuY29tIn0.lg2T8dKVfic_JU6qzNBqDuw3RFUq7Da5UO37eY3W-cOOb9UqijxGYj7d-z8qK1UJjRRcDg-rTMzYQbKCLVxjBw")
         assertThat(networkRule.idTokenValidator.lastIdTokenParameters.nonce).isEqualTo(client.flowContext.nonce)
         assertThat(networkRule.idTokenValidator.lastIdTokenParameters.maxAge).isEqualTo(65)
@@ -226,11 +221,11 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/interactResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         assertThat(clientResult.result.flowContext.interactionHandle).isEqualTo("029ZAB")
 
         val client = clientResult.result
-        val exchangeCodesResult = client.exchangeInteractionCodeForTokens(createRemediation(emptyList())) as OidcClientResult.Error<Token>
+        val exchangeCodesResult = client.exchangeInteractionCodeForTokens(createRemediation(emptyList())) as OAuth2ClientResult.Error<Token>
         assertThat(exchangeCodesResult.exception.message).isEqualTo("Invalid remediation.")
     }
 
@@ -244,11 +239,11 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json").setResponseCode(499)
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         assertThat(resumeResult.result.remediations).hasSize(4)
     }
 
@@ -262,11 +257,11 @@ class InteractionCodeFlowTest {
             response.testBodyFromFile("client/identifyRemediationResponse.json").setResponseCode(500)
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
         assertThat(client.flowContext.interactionHandle).isEqualTo("029ZAB")
 
-        val resumeResult = client.resume() as OidcClientResult.Error<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Error<IdxResponse>
         assertThat(resumeResult.exception.message).isEqualTo("HTTP Error: status code - 500")
     }
 }

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxPollCapabilityTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxPollCapabilityTest.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.idx.kotlin.dto
 
+import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
@@ -24,9 +25,14 @@ import com.okta.testing.testBodyFromFile
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class IdxPollCapabilityTest {
     @get:Rule val networkRule = NetworkRule()
+
+    private val testUri = Uri.parse("test.okta.com/login")
 
     @Test fun testAuthenticatorPoll(): Unit = runBlocking {
         networkRule.enqueue(path("/oauth2/default/v1/interact")) { response ->
@@ -42,15 +48,14 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/challengeAuthenticatorRemediationResponseLongPoll.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].authenticators[0].capabilities.get<IdxPollAuthenticatorCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(flow) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.isLoginSuccessful).isTrue()
         assertThat(delays).containsExactly(4000L, 8000L)
@@ -67,15 +72,14 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/selectAuthenticatorAuthenticateRemediationResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].authenticators[0].capabilities.get<IdxPollAuthenticatorCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(flow) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.remediations.first().name).isEqualTo("select-authenticator-authenticate")
         assertThat(delays).containsExactly(4000L)
@@ -95,15 +99,14 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/challengePollRemediationResponseLong.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].capabilities.get<IdxPollRemediationCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(flow) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.isLoginSuccessful).isTrue()
         assertThat(delays).containsExactly(4000L, 8000L)
@@ -120,15 +123,14 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/selectAuthenticatorAuthenticateRemediationResponse.json")
         }
 
-        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
-        val client = clientResult.result
-        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
+        val flow = InteractionCodeFlow().apply { start(testUri) }
+        val resumeResult = flow.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].capabilities.get<IdxPollRemediationCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(flow) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.remediations.first().name).isEqualTo("select-authenticator-authenticate")
         assertThat(delays).containsExactly(4000L)

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxPollCapabilityTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxPollCapabilityTest.kt
@@ -16,9 +16,8 @@
 package com.okta.idx.kotlin.dto
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.idx.kotlin.client.InteractionCodeFlow
-import com.okta.idx.kotlin.client.InteractionCodeFlow.Companion.createInteractionCodeFlow
 import com.okta.testing.network.NetworkRule
 import com.okta.testing.network.RequestMatchers.path
 import com.okta.testing.testBodyFromFile
@@ -43,15 +42,15 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/challengeAuthenticatorRemediationResponseLongPoll.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].authenticators[0].capabilities.get<IdxPollAuthenticatorCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OidcClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.isLoginSuccessful).isTrue()
         assertThat(delays).containsExactly(4000L, 8000L)
@@ -68,15 +67,15 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/selectAuthenticatorAuthenticateRemediationResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].authenticators[0].capabilities.get<IdxPollAuthenticatorCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OidcClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.remediations.first().name).isEqualTo("select-authenticator-authenticate")
         assertThat(delays).containsExactly(4000L)
@@ -96,15 +95,15 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/challengePollRemediationResponseLong.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].capabilities.get<IdxPollRemediationCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OidcClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.isLoginSuccessful).isTrue()
         assertThat(delays).containsExactly(4000L, 8000L)
@@ -121,15 +120,15 @@ class IdxPollCapabilityTest {
             response.testBodyFromFile("client/selectAuthenticatorAuthenticateRemediationResponse.json")
         }
 
-        val clientResult = networkRule.createOidcClient().createInteractionCodeFlow("test.okta.com/login") as OidcClientResult.Success<InteractionCodeFlow>
+        val clientResult = InteractionCodeFlow.create("test.okta.com/login") as OAuth2ClientResult.Success<InteractionCodeFlow>
         val client = clientResult.result
-        val resumeResult = client.resume() as OidcClientResult.Success<IdxResponse>
+        val resumeResult = client.resume() as OAuth2ClientResult.Success<IdxResponse>
         val resumeResponse = resumeResult.result
 
         val capability = resumeResponse.remediations[0].capabilities.get<IdxPollRemediationCapability>()!!
         val delays = mutableListOf<Long>()
         capability.delayFunction = { delays += it }
-        val pollResult = capability.poll(client) as OidcClientResult.Success<IdxResponse>
+        val pollResult = capability.poll(client) as OAuth2ClientResult.Success<IdxResponse>
 
         assertThat(pollResult.result.remediations.first().name).isEqualTo("select-authenticator-authenticate")
         assertThat(delays).containsExactly(4000L)

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -27,6 +27,11 @@ android {
     buildFeatures {
         buildConfig = false
     }
+    packagingOptions {
+        resources {
+            excludes += 'META-INF/*'
+        }
+    }
     namespace 'com.okta.testing'
 }
 
@@ -38,4 +43,6 @@ dependencies {
     api deps.okio.core
     api deps.truth
     api deps.jackson_databind
+    api deps.mockk.agent
+    api deps.mockk.android
 }

--- a/test-utils/src/main/java/com/okta/testing/network/TestIdTokenValidator.kt
+++ b/test-utils/src/main/java/com/okta/testing/network/TestIdTokenValidator.kt
@@ -16,7 +16,7 @@
 package com.okta.testing.network
 
 import com.okta.authfoundation.client.IdTokenValidator
-import com.okta.authfoundation.client.OidcClient
+import com.okta.authfoundation.client.OAuth2Client
 import com.okta.authfoundation.jwt.Jwt
 
 class TestIdTokenValidator : IdTokenValidator {
@@ -25,7 +25,7 @@ class TestIdTokenValidator : IdTokenValidator {
     @Volatile lateinit var lastIdTokenParameters: IdTokenValidator.Parameters
         private set
 
-    override suspend fun validate(oidcClient: OidcClient, idToken: Jwt, parameters: IdTokenValidator.Parameters) {
+    override suspend fun validate(client: OAuth2Client, idToken: Jwt, parameters: IdTokenValidator.Parameters) {
         lastIdToken = idToken
         lastIdTokenParameters = parameters
     }

--- a/versions.gradle
+++ b/versions.gradle
@@ -7,7 +7,7 @@ versions.androidx_test_orchestrator = '1.4.2'
 versions.androidx_text_uiautomator = '2.2.0'
 versions.android_gradle_plugin = '8.1.2'
 versions.appcompat = '1.4.2'
-versions.auth_foundation = '1.2.1'
+versions.auth_foundation = '2.0.0'
 versions.bouncycastle = '1.78.1'
 versions.compose = '1.5.4'
 versions.constraint_layout = '2.1.4'
@@ -31,6 +31,7 @@ versions.material = '1.6.1'
 versions.material_compose_theme = '1.1.17'
 versions.mockito_core = '4.6.1'
 versions.mockito_kotlin = '4.0.0'
+versions.mockk = '1.13.11'
 versions.navigation = '2.5.1'
 versions.okhttp = '4.11.0'
 versions.okio = '3.5.0'
@@ -43,7 +44,7 @@ versions.truth = '1.1.5'
 ext.versions = versions
 
 def build_versions = [:]
-build_versions.min_sdk = 21
+build_versions.min_sdk = 23
 build_versions.compile_sdk = 34
 build_versions.target_sdk = 34
 ext.build_versions = build_versions
@@ -136,6 +137,11 @@ mockito.core = "org.mockito:mockito-core:$versions.mockito_core"
 mockito.kotlin = "org.mockito.kotlin:mockito-kotlin:$versions.mockito_kotlin"
 deps.mockito = mockito
 
+def mockk = [:]
+mockk.android = "io.mockk:mockk-android:$versions.mockk"
+mockk.agent = "io.mockk:mockk-agent:$versions.mockk"
+deps.mockk = mockk
+
 def navigation = [:]
 navigation.fragment_ktx = "androidx.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.ui_ktx = "androidx.navigation:navigation-ui-ktx:$versions.navigation"
@@ -156,7 +162,6 @@ deps.okio = okio
 def okta = [:]
 okta.management_sdk = "com.okta.sdk:okta-sdk-impl:$versions.okta_management"
 okta.auth_foundation = "com.okta.kotlin:auth-foundation:$versions.auth_foundation"
-okta.auth_foundation_bootstrap = "com.okta.kotlin:auth-foundation-bootstrap:$versions.auth_foundation"
 deps.okta = okta
 
 deps.robolectric = "org.robolectric:robolectric:$versions.robolectric"


### PR DESCRIPTION
This PR updates authfoundation dependency to version 2.0.0. Most of the changes are:
1. Changing OidcClientResult -> OAuth2ClientResult
2. Changing test fixtures to not rely on OidcConfiguration containing all SDK utilities