### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.0.1] 2024-07-22
+
+### Changed
+- Expose DeviceTokenCookieJar as InternalAuthFoundationApi
+
 ## [3.0.0] 2024-06-14
 
 [Commits](https://github.com/okta/okta-idx-android/compare/2.4.1...3.0.0)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ do not have an account manager, please reach out to oie@okta.com for more inform
 Add the `Okta IDX Kotlin` dependency to your `build.gradle` file:
 
 ```gradle
-implementation 'com.okta.android:okta-idx-kotlin:3.0.0'
+implementation 'com.okta.android:okta-idx-kotlin:3.0.1'
 ```
 
 See the [CHANGELOG](CHANGELOG.md) for the most recent changes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,6 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=okta
 POM_DEVELOPER_NAME=Okta
 
-VERSION_NAME=3.0.0
+VERSION_NAME=3.0.1
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/native-authentication/build.gradle
+++ b/native-authentication/build.gradle
@@ -32,7 +32,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs += ["-Xopt-in=com.okta.authfoundation.InternalAuthFoundationApi"]
+        freeCompilerArgs += ["-opt-in=com.okta.authfoundation.InternalAuthFoundationApi"]
     }
 
     buildFeatures {

--- a/okta-idx-kotlin/build.gradle
+++ b/okta-idx-kotlin/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs += ["-Xopt-in=com.okta.authfoundation.InternalAuthFoundationApi"]
+        freeCompilerArgs += ["-opt-in=com.okta.authfoundation.InternalAuthFoundationApi"]
     }
 
     buildFeatures {

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/client/DeviceTokenCookieJar.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/client/DeviceTokenCookieJar.kt
@@ -16,6 +16,7 @@
 package com.okta.idx.kotlin.client
 
 import com.okta.authfoundation.AuthFoundationDefaults
+import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.DeviceTokenProvider
 import kotlinx.coroutines.runBlocking
 import okhttp3.Cookie
@@ -23,7 +24,8 @@ import okhttp3.CookieJar
 import okhttp3.HttpUrl
 import kotlin.time.Duration.Companion.seconds
 
-internal class DeviceTokenCookieJar : CookieJar {
+@InternalAuthFoundationApi
+class DeviceTokenCookieJar : CookieJar {
     private val savedCookiesCache = mutableMapOf<String, List<Cookie>>()
     private val oidcClock by lazy { AuthFoundationDefaults.clock }
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -21,7 +21,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        freeCompilerArgs += ["-Xopt-in=com.okta.authfoundation.InternalAuthFoundationApi"]
+        freeCompilerArgs += ["-opt-in=com.okta.authfoundation.InternalAuthFoundationApi"]
     }
 
     buildFeatures {


### PR DESCRIPTION
This release exposes DeviceTokenCookieJar for cases where this SDK might not be setting AuthfoundationDefaults.cookieJar property properly. This should be a simple fix for the time being, but more investigation needs to be done to figure out how to set the cookie jar properly in this SDK