### PR TITLE
Release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2] 2025-03-10
+
+[Commits](https://github.com/okta/okta-idx-android/compare/3.0.1...3.0.2)
+
+### Fixed
+- Fixed a crash when using this SDK in Flutter
+
 ## [3.0.1] 2024-09-17
 
 [Commits](https://github.com/okta/okta-idx-android/compare/3.0.0...3.0.1)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ do not have an account manager, please reach out to oie@okta.com for more inform
 Add the `Okta IDX Kotlin` dependency to your `build.gradle` file:
 
 ```gradle
-implementation 'com.okta.android:okta-idx-kotlin:3.0.1'
+implementation 'com.okta.android:okta-idx-kotlin:3.0.2'
 ```
 
 See the [CHANGELOG](CHANGELOG.md) for the most recent changes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,6 +36,6 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=okta
 POM_DEVELOPER_NAME=Okta
 
-VERSION_NAME=3.0.1
+VERSION_NAME=3.0.2
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-authFoundation = "2.0.2"
+authFoundation = "2.0.3"
 androidxConstraintlayout = "2.2.0"
 androidxDatastorePreferences = "1.1.2"
 androidxTest = "1.6.1"

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/client/InteractionCodeFlow.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/client/InteractionCodeFlow.kt
@@ -18,6 +18,7 @@ package com.okta.idx.kotlin.client
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import com.okta.authfoundation.AuthFoundationDefaults
+import com.okta.authfoundation.SdkDefaults
 import com.okta.authfoundation.client.OAuth2Client
 import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.authfoundation.client.OidcConfiguration
@@ -45,7 +46,7 @@ class InteractionCodeFlow(val client: OAuth2Client) {
     companion object {
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
-            AuthFoundationDefaults.cookieJar = DeviceTokenCookieJar()
+            SdkDefaults.getCookieJar = { DeviceTokenCookieJar() }
         }
     }
 


### PR DESCRIPTION
This release updates authfoundation to 2.0.3, which allows us to set SDK defaults in a non-crashing way